### PR TITLE
Change license of cams2wrfchem.py from MIT to BSD 3-clause (#49)

### DIFF
--- a/run/real/cams2wrfchem.py
+++ b/run/real/cams2wrfchem.py
@@ -1,28 +1,8 @@
+# Copyright (c) 2025 LATMOS (France, UMR 8190) and IGE (France, UMR 5001).
+#
+# License: BSD 3-clause "new" or "revised" license (BSD-3-Clause).
+
 """Prepare WRF-chem emission input files using CAMS emission inventory.
-
-Copyright (c) 2024 Regional-Modeling-LATMOS-IGE.
-
-This software is released under the terms of the Expat (aka MIT) license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
--------------------------------------------------------------------------------
 
 Notes:
 


### PR DESCRIPTION
The two licenses are more or less equivalent, but let us try to limit the number of different licenses we use in this repository.