### PR TITLE
Add nco and cdo to the list of dependencies for pre-processing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ preprocess = [
     "netcdf4",
     "xarray",
     "shapely",
+    "nco",
+    "cdo",
 ]
 wrfpp = [
     "pyproj",


### PR DESCRIPTION
This commit fixes issue #99.