### PR TITLE
Make the units method of GenericDatasetAccessor work for derived variables

### DIFF
--- a/postprocess/wrfpp.py
+++ b/postprocess/wrfpp.py
@@ -154,7 +154,7 @@ class GenericDatasetAccessor(ABC):
             The units of this variable as defined in the NetCDF file.
 
         """
-        attrs = self[varname].attrs
+        attrs = getattr(self, varname).attrs
         try:
             units = attrs["units"]
         except KeyError:


### PR DESCRIPTION
This fixes issue #133.