### PR TITLE
Remove bad quality check in wrfpp for stereographic projection

### DIFF
--- a/postprocess/wrfpp.py
+++ b/postprocess/wrfpp.py
@@ -379,9 +379,6 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
             raise ValueError("Invalid value for MAP_PROJ_CHAR.")
         if self.attrs["STAND_LON"] != self.attrs["CEN_LON"]:
             raise ValueError("Inconsistency in central longitude values.")
-        for which in ("TRUELAT1", "TRUELAT2", "MOAD_CEN_LAT"):
-            if round(self.attrs[which], 4) != round(self.attrs["CEN_LAT"], 4):
-                raise ValueError("Inconsistency in true latitude values.")
         proj = dict(
             proj="stere",
             lat_0=self.attrs["POLE_LAT"],


### PR DESCRIPTION
When used on wrfout files that use a stereographic projection,
wrfpp was checking that the central latitude was equal to the
first true latitude of the projection. This does not have to be
the case, so this quality check was removed.

This commit fixes issue #135.
