### PR TITLE
Update namelist following PR92 in WRF-Chem - issue#159

### DIFF
--- a/run/real/namelist.input.YYYY
+++ b/run/real/namelist.input.YYYY
@@ -210,7 +210,7 @@
 
  &chem
 ! Chemistry options
- chem_opt                            = 202, 202, 202,
+ chem_opt                            = 212, 212, 212,
  chemdt                              = 0, 0, 0,
  phot_opt                            = 4, 4, 4,
  has_o3_exo_coldens                  = .true.


### PR DESCRIPTION
Update the default value of chem_opt in the namelist to 212 in order to reflect the changes in the model brought by PR92 in WRF-Chem.