### PR TITLE
Update chem_opt to 212 in run/real/namelist.input.YYYY

### DIFF
--- a/run/real/namelist.input.YYYY
+++ b/run/real/namelist.input.YYYY
@@ -210,7 +210,7 @@
 
  &chem
 ! Chemistry options
- chem_opt                            = 202, 202, 202,
+ chem_opt                            = 212, 212, 212,
  chemdt                              = 0, 0, 0,
  phot_opt                            = 4, 4, 4,
  has_o3_exo_coldens                  = .true.


### PR DESCRIPTION
This commit changes the default chem_opt in namelist.input.YYYY from 202 to 212
Advanced DMS and MSA chemistry was added to MOZART-MOSAIC in WRF-Chem-Polar, by extending option chem_opt = 202. However this means that we could no longer run MOZART-MOSAIC with simplified DMS chemistry as in the base WRF-Chem. In PR92, we have moved these developments to a new option chem_opt = 212, which is now the new recommended option for our best setup.