### PR TITLE
Add the possibility for users to choose which metrics to plot for maps

### DIFF
--- a/testing/plot-surface-maps.py
+++ b/testing/plot-surface-maps.py
@@ -167,7 +167,6 @@ with PdfPages(args.output) as pdf:
     for metric, variable in itertools.product(metrics, variables):
         print(f"Plotting map: {metric} of {variable}...")
 
-        npmetric = getattr(np, metric)
         npnanmetric = getattr(np, f"nan{metric}")
 
         # Select values for the colourbar min and max
@@ -199,7 +198,7 @@ with PdfPages(args.output) as pdf:
                 array = array.isel(bottom_top=0)
             elif "bottom_top_stag" in array.dims:
                 array = array.isel(bottom_top_stag=0)
-            data = npmetric(array.isel(Time=run["time_idx"]), axis=0)
+            data = npnanmetric(array.isel(Time=run["time_idx"]), axis=0)
             lon, lat = ds.lonlat_var(variable)
 
             # Prepare axes and plot


### PR DESCRIPTION
Currently, the script that creates surface maps plots the
time-averaged values of the quantity of interest.

In issue #83, we mentioned plotting surface maps of time-min
and time-max values as well.

This commit adds this capability. It relates to issue #69.
