### PR TITLE
Allow interp_h and related methods to work on arrays in wrfpp

### DIFF
--- a/postprocess/wrfpp.py
+++ b/postprocess/wrfpp.py
@@ -515,7 +515,8 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
         Parameters
         ----------
         var: str | xr.DataArray
-             The name of the variable or a WRF-conforming data array.
+             The name of the variable or a data array defined on the same grid
+             as the underlying dataset.
 
         Returns
         -------
@@ -585,7 +586,8 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
         Parameters
         ----------
         var: str | xr.DataArray
-            The name of the variable or a WRF-conforming data array.
+            The name of the variable or a data array defined on the same grid
+            as the underlying dataset.
 
         Returns
         -------
@@ -634,7 +636,8 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
         Parameters
         ----------
         var: str | xr.DataArray
-            The name of the variable or a WRF-conforming data array.
+            The name of the variable or a data array defined on the same grid
+            as the underlying dataset.
 
         Returns
         -------
@@ -648,12 +651,13 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
         return scipy.spatial.Delaunay(np.hstack([x, y]))
 
     def interp_h(self, var, lon, lat, times=None, levels=None):
-        """Interpolate WRF variable (native or derived) horizontally.
+        """Interpolate WRF variable or WRF-like array horizontally.
 
         Parameters
         ----------
         var: str | xr.DataArray
-             The name of the variable or a WRF-conforming data array.
+             The name of the variable or a data array defined on the same grid
+             as the underlying dataset.
         lon: scalar or numeric array
             Longitude(s) at which to interpolate.
         lat: scalar or numeric array

--- a/postprocess/wrfpp.py
+++ b/postprocess/wrfpp.py
@@ -509,13 +509,13 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
 
     # Coordinates
 
-    def dimensionality(self, varname):
-        """Return the dimensionality of given variable.
+    def dimensionality(self, var):
+        """Return the dimensionality of given variable or array.
 
         Parameters
         ----------
-        varname: str
-             The name of the variable of interest.
+        var: str | xr.DataArray
+             The name of the variable or a WRF-conforming data array.
 
         Returns
         -------
@@ -529,7 +529,8 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
 
         """
         out = ""
-        for dim in getattr(self, varname).dims:
+        array = getattr(self, var) if isinstance(var, str) else var
+        for dim in array.dims:
             if dim == "Time":
                 out += "t"
             elif dim in ("bottom_top", "bottom_top_stag"):
@@ -578,13 +579,13 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
             lats = lats[0]
         return lons, lats
 
-    def lonlat_var(self, varname):
-        """Return the longitude and latitude arrays for given variable.
+    def lonlat_var(self, var):
+        """Return longitude and latitude arrays for given variable or array.
 
         Parameters
         ----------
-        varname: str
-            The name of the variable of interest.
+        var: str | xr.DataArray
+            The name of the variable or a WRF-conforming data array.
 
         Returns
         -------
@@ -594,9 +595,10 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
             The latitude values.
 
         """
+        array = getattr(self, var) if isinstance(var, str) else var
         dims = [
             dim
-            for dim in getattr(self, varname).dims
+            for dim in array.dims
             if dim.startswith("south_north") or dim.startswith("west_east")
         ]
         if dims == ["south_north", "west_east"]:
@@ -606,11 +608,14 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
         elif dims == ["south_north", "west_east_stag"]:
             lon, lat = self["XLONG_U"], self["XLAT_U"]
         else:
-            msg = f"Cannot get lon/lat for variable {varname}."
+            msg = "Cannot get lon/lat for given variable or array."
             raise ValueError(msg)
         # Quality controls on longitude and latitude
         if lon.dims != lat.dims or lon.shape != lat.shape:
             msg = "Inconsistent dims or shapes for longitudes and latitudes."
+            raise ValueError(msg)
+        if not isinstance(var, str) and array.shape[-2:] != lon.shape[-2:]:
+            msg = "Cannot get lon/lat values for a horizontal subset of array."
             raise ValueError(msg)
         if lon.dims[0] != "Time":
             msg = f"Expecting first dimension to be Time, got {lon.dims[0]}."
@@ -623,13 +628,13 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
 
     # Interpolation
 
-    def _delaunay_xy(self, varname):
-        """Return the (x,y) Delaunay triangulation for given variable.
+    def _delaunay_xy(self, var):
+        """Return the (x,y) Delaunay triangulation for variable or array.
 
         Parameters
         ----------
-        varname: str
-            The name of the variable of interest.
+        var: str | xr.DataArray
+            The name of the variable or a WRF-conforming data array.
 
         Returns
         -------
@@ -637,18 +642,18 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
             The Delaunay triangulation in (x,y) space for given variable.
 
         """
-        x, y = self.ll2xy(*self.lonlat_var(varname))
+        x, y = self.ll2xy(*self.lonlat_var(var))
         x = np.expand_dims(x.flatten(), 1)
         y = np.expand_dims(y.flatten(), 1)
         return scipy.spatial.Delaunay(np.hstack([x, y]))
 
-    def interp_h(self, varname, lon, lat, times=None, levels=None):
+    def interp_h(self, var, lon, lat, times=None, levels=None):
         """Interpolate WRF variable (native or derived) horizontally.
 
         Parameters
         ----------
-        varname: str
-            The name of the variable of interest.
+        var: str | xr.DataArray
+             The name of the variable or a WRF-conforming data array.
         lon: scalar or numeric array
             Longitude(s) at which to interpolate.
         lat: scalar or numeric array
@@ -680,8 +685,8 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
         poorly chosen for the domain.
 
         """
-        data = getattr(self, varname)
-        dimensionality = self.dimensionality(varname)
+        data = getattr(self, var) if isinstance(var, str) else var
+        dimensionality = self.dimensionality(var)
 
         # Transform lon and lat into meshgridded arrays
         if not hasattr(lon, "shape"):
@@ -699,14 +704,14 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
 
         # Set up the list(s) of time and level indices
         if "t" not in dimensionality and times is not None:
-            msg = f"Cannot specify times for variable {varname}."
+            msg = "Cannot specify times for given variable or array."
             raise ValueError(msg)
         elif "t" in dimensionality and times is None:
             times = range(data.shape[dimensionality.index("t")])
         elif "t" in dimensionality and not _is_iterable(times):
             times = [times]
         if "z" not in dimensionality and levels is not None:
-            msg = f"Cannot specify levels for variable {varname}."
+            msg = "Cannot specify levels for given variable or array."
             raise ValueError(msg)
         elif "z" in dimensionality and levels is None:
             levels = range(data.shape[dimensionality.index("z")])
@@ -721,7 +726,7 @@ class WRFDatasetAccessor(GenericDatasetAccessor):
         # Prepare the interpolation
         values_in = data.isel(**selection).values
         interpolator = scipy.interpolate.LinearNDInterpolator
-        delaunay = self._delaunay_xy(varname)
+        delaunay = self._delaunay_xy(var)
         x, y = self.ll2xy(lon, lat)
 
         # For clarity, we handle each dimensionality manually


### PR DESCRIPTION
Before this commit, the following WRF accessor methods only worked
when given the name of a variable:

 - `dimensionality`
 - `lonlat_var`
 - `_delaunay_xy`
 - `interp_h`

where said variable name could be either a native WRF variable
or a derived WRF variable.

With this commit, one can use these methods by directly
providing a sufficiently compliant array, such as in:

```Python
twice_rh = 2 * wrf.relative_humidity[:]
wrf.interp_h(twice_rh, ...)
```

This commit will help us complete issue #9.